### PR TITLE
Build parser tree

### DIFF
--- a/lib/calliope/parser.ex
+++ b/lib/calliope/parser.ex
@@ -7,9 +7,12 @@ defmodule Calliope.Parser do
   @tab      "\t"
 
   def parse([]), do: []
-  def parse([_|t]) do
-    parse(t)
+  def parse(l) do
+    build_tree(parse_lines(l))
   end
+
+  def parse_lines([]), do: []
+  def parse_lines([h|t]), do: [parse_line(h)|parse_lines(t)]
 
   def parse_line([], acc), do: acc
   def parse_line([h|t], acc//[]) do

--- a/test/calliope/parser_test.exs
+++ b/test/calliope/parser_test.exs
@@ -14,18 +14,18 @@ defmodule CalliopeParserTest do
 
   @parsed_tokens [
       [ tag: "section", classes: ["container"] ],
-      [ tag: "h1", indent: 1, content: "Calliope" ],
-      [ tag: "h2", indent: 1, content: "An Elixir Haml Parser" ],
-      [ id: "main", indent: 1, classes: ["content"] ],
+      [ indent: 1, tag: "h1", content: "Calliope" ],
+      [ indent: 1, tag: "h2", content: "An Elixir Haml Parser" ],
+      [ indent: 1, id: "main", classes: ["content"] ],
       [ indent: 2, content: "Welcome to Calliope" ],
       [ tag: "section", classes: ["container"] ]
     ]
 
   @nested_tree [
       [ tag: "section", classes: ["container"], children: [
-          [ tag: "h1", indent: 1, content: "Calliope" ],
-          [ tag: "h2", indent: 1, content: "An Elixir Haml Parser"],
-          [ id: "main", indent: 1, classes: ["content"], children: [
+          [ indent: 1, tag: "h1", content: "Calliope" ],
+          [ indent: 1, tag: "h2",content: "An Elixir Haml Parser"],
+          [ indent: 1, id: "main", classes: ["content"], children: [
               [ indent: 2, content: "Welcome to Calliope" ]
             ]
           ],
@@ -35,6 +35,10 @@ defmodule CalliopeParserTest do
     ]
 
   @children Keyword.fetch!(List.first(@nested_tree), :children)
+
+  test :parse do
+    assert parse(@tokens) == @nested_tree
+  end
 
   test :parse_line do
     assert parsed_tokens(0) == parsed_line_tokens(tokens(0))
@@ -48,10 +52,6 @@ defmodule CalliopeParserTest do
   test :build_tree do
     assert @nested_tree == build_tree @parsed_tokens
   end
-
-  # test :process_children do
-  #   assert { [], @children } == process_children(@parsed_tokens)
-  # end
 
   test :pop_children do
     assert { [[indent: 0], [indent: 1]], [[ indent: 1]] } == pop_children([indent: 0], [[ indent: 1], [indent: 0], [indent: 1]])


### PR DESCRIPTION
Parent indent defaults to 0. Extract bigger_indentation?
Change deprecated Enum.first to List.first
