### PR TITLE
Add :javascript filter support.

### DIFF
--- a/lib/calliope/exceptions.ex
+++ b/lib/calliope/exceptions.ex
@@ -4,6 +4,7 @@ defmodule CalliopeException do
   def messages do
     [
       too_deep_indent:        "Indentation was too deep on line number: #",
+      unknown_filter:         "Unknown filter on line number: #",
       multiple_ids_assigned:  "tag id is assigned multiple times on line number #",
       unknown:                "Something wicked this way comes"
     ]

--- a/lib/calliope/parser.ex
+++ b/lib/calliope/parser.ex
@@ -11,6 +11,7 @@ defmodule Calliope.Parser do
   @comment  "/"
   @script   "="
   @smart    "-"
+  @filter   ":"
 
   def parse([]), do: []
   def parse(l) do
@@ -38,6 +39,7 @@ defmodule Calliope.Parser do
       @comment  -> handle_comment(val) ++ acc
       @script   -> [ script: val ] ++ acc
       @smart    -> [ smart_script: String.strip(val) ] ++ acc
+      @filter   -> handle_filter(acc, val)
       _         -> [ content: String.strip(h) ] ++ acc
     end
     parse_line(t, acc)
@@ -49,6 +51,13 @@ defmodule Calliope.Parser do
       line[:id] -> raise_error :multiple_ids_assigned, line[:line_number]
       true -> [ id: id ] ++ line
     end
+  end
+
+  def handle_filter(line, "javascript") do
+    [ tag: "script", attributes: "type=\"text/javascript\"" ] ++ line
+  end
+  def handle_filter(line, _unknown_filter) do
+    raise_error(:unknown_filter, line[:line_number])
   end
 
   def build_attributes(value) do

--- a/test/calliope/render_test.exs
+++ b/test/calliope/render_test.exs
@@ -8,6 +8,9 @@ defmodule CalliopeRenderTest do
 %section.container(class= "blue")
   %article
     %h1= title
+    :javascript
+      var x = 5;
+      var y = 10;
     / %h1 An important inline comment
     /[if IE]
       %h2 An Elixir Haml Parser
@@ -19,6 +22,10 @@ defmodule CalliopeRenderTest do
     <section class="container blue">
       <article>
         <h1><%= title %></h1>
+        <script type="text/javascript">
+          var x = 5;
+          var y = 10;
+        </script>
         <!-- <h1>An important inline comment</h1> -->
         <!--[if IE]> <h2>An Elixir Haml Parser</h2> <![endif]-->
         <div id="main" class="content">


### PR DESCRIPTION
Also groundwork for additional filter types.

Automated the parse_line so that you can't forget to add one. The test
for '%img' was missing.
