### PR TITLE
Upgraded and corrected attributes tokenizer and parser

### DIFF
--- a/lib/calliope/parser.ex
+++ b/lib/calliope/parser.ex
@@ -64,7 +64,7 @@ defmodule Calliope.Parser do
     String.slice(value, 0, String.length(value)-1) |>
       String.replace(~r/class[=:]\s?['"](.*)['"]/r, "") |>
       String.replace(~r/id[=:]\s?['"](.*)['"]/r, "") |>
-      String.replace(~r/:\s([\'"])/, "=\\1") |>
+      String.replace(~r/:\s+([\'"])/, "=\\1") |>
       String.replace(~r/[:=]\s?(?!.*["'])(@?\w+)\s?/, "='#\{\\1}'") |>
       String.replace(~r/[})]$/, "") |>
       String.replace(~r/"(.+?)"\s=>\s(@?\w+)\s?/, "\\1='#\{\\2}'") |>

--- a/lib/calliope/tokenizer.ex
+++ b/lib/calliope/tokenizer.ex
@@ -1,6 +1,17 @@
 defmodule Calliope.Tokenizer do
 
-  @regex  ~r/(?:(^[\t| ]+)|(\/\s)|(\/\[\w+])|([%.#][-:\w]+)|([{(].+?['"][)}])|(.+))\s*/
+  @indent       ~S/(^[\t| ]+)|(\/\s)|(\/\[\w+])/
+  @tag_class_id ~S/([%.#][-:\w]+)/
+  @keyword      ~S/[-:\w]+/
+  @value        ~S/(?:(?:'.*?')|(?:".*?"))/
+  @hash_param   ~s/\\s*#{@keyword}:\\s*#{@value}\\s*/
+  @hash_params  ~s/({#{@hash_param}(?:,#{@hash_param})*?})/
+  @html_param   ~s/\\s*#{@keyword}\\s*=\\s*#{@value}\\s*/
+  @html_params  ~s/(\\(#{@html_param}(?:\\s#{@html_param})*?\\))/
+  @rest         ~S/(.+)/
+
+  @regex        ~r/(?:#{@indent}|#{@tag_class_id}|#{@hash_params}|#{@html_params}|#{@rest})\s*/
+
 
   def tokenize(haml) when is_binary(haml) do
     Regex.split(~r/\n/, haml, trim: true) |> tokenize |> filter |> tokenize_identation |> index

--- a/test/calliope/parser_test.exs
+++ b/test/calliope/parser_test.exs
@@ -103,6 +103,7 @@ defmodule CalliopeParserTest do
 
   test :build_attributes do
     assert "class='#\{@class_name}'" == build_attributes("class: @class_name }")
+    assert "for='name'" == build_attributes("for:  'name' }")
     assert "class='#\{@class_name}'" == build_attributes("class=@class_name }")
     assert "style='margin-top: 5px'" == build_attributes("style: 'margin-top: 5px' }")
     assert "style=\"margin-top: 5px\"" == build_attributes("style: \"margin-top: 5px\" }")

--- a/test/calliope/render_test.exs
+++ b/test/calliope/render_test.exs
@@ -14,6 +14,7 @@ defmodule CalliopeRenderTest do
     / %h1 An important inline comment
     /[if IE]
       %h2 An Elixir Haml Parser
+    %label.cl1\{ for:  "test", class: " cl2"  \} Label
     #main.content
       Welcome to Calliope}
 
@@ -28,6 +29,7 @@ defmodule CalliopeRenderTest do
         </script>
         <!-- <h1>An important inline comment</h1> -->
         <!--[if IE]> <h2>An Elixir Haml Parser</h2> <![endif]-->
+        <label class="cl1 cl2" for="test">Label</label>
         <div id="main" class="content">
           Welcome to Calliope
         </div>
@@ -47,7 +49,7 @@ defmodule CalliopeRenderTest do
   test :eval do
     result = "<a href='http://example.com'>Example</a>"
     assert result == render "%a{href: 'http://example.com'} Example" |> eval []
-    assert result == render(~s{%a(href: 'http://example.com')= "Example"}) |> eval [conn: []]
+    assert result == render(~s(%a{href: 'http://example.com'}= "Example")) |> eval [conn: []]
   end
 
   test :render_with_params do

--- a/test/calliope/tokenizer_test.exs
+++ b/test/calliope/tokenizer_test.exs
@@ -69,12 +69,19 @@ defmodule CalliopeTokenizerTest do
   end
 
   test :tokenize_line do
-    assert [[1, "%section", ".container", ".blue", "{src='#', data='cool'} ", "Calliope"]] ==
-      tokenize("\n%section.container.blue{src='#', data='cool'} Calliope")
-    assert [[1, "%section", ".container", "(src='#', data='cool') ", "Calliope"]] ==
-      tokenize("\n%section.container(src='#', data='cool') Calliope")
+    assert [[1, "%section", ".container", ".blue", "{src:'#', data:'cool'} ", "Calliope"]] ==
+      tokenize("\n%section.container.blue{src:'#', data:'cool'} Calliope")
+    assert [[1, "%section", ".container", "(src='#' data='cool') ", "Calliope"]] ==
+      tokenize("\n%section.container(src='#' data='cool') Calliope")
     assert [[1, "\t", "%a", "{href: \"#\"} ", "Learning about \#{title}"]] ==
       tokenize("\t%a{href: \"#\"} Learning about \#{title}")
+
+    # allowing spaces after the attribute values before closing curly brace
+    assert [[1, "%label", ".cl1", "{ for:  'test', class:  ' cl2' } ", "Label" ]] ==
+      tokenize("%label.cl1{ for:  'test', class:  ' cl2' } Label")
+
+    assert [[1, "%label", "{ for: \"\#{@id}\", class: \"\#{@class}\" } ", "Label" ]] ==
+      tokenize("%label{ for: \"\#{@id}\", class: \"\#{@class}\" } Label")
   end
 
   test :tokenize_identation do


### PR DESCRIPTION
Hi there. Here's my small contribution.

Tokenizer and parser now correctly parse:

`%div{ key: "#{value}", key:       'value with double " quotes'   } Content`
- random spaces between key and value
- any number of spaces after the last parameter and curly brace
- content after the curly brace (conflicted with spaces before the closing brace)
- any number of #{...} extrapolations inside the values

Also the format of HTML-like and Ruby-hash-like attributes has been corrected according to the spec, and recognized only when follow exactly:
- `{ keyword: "double quoted value", keyword2: 'single quoted value' }``. Note the use of strictly ":" as key-value delimeter.
- `( keyword="value" keyword2="value" }`. Note the use of strictly "= and no commas between attributes.

Let me know how it looks. Cheers.

P.S. I'm also planning on extending the support to `{ :keyword => "value" }`.
