### PR TITLE
Fix #26, allow use of parens and brackets

### DIFF
--- a/lib/calliope/tokenizer.ex
+++ b/lib/calliope/tokenizer.ex
@@ -10,11 +10,10 @@ defmodule Calliope.Tokenizer do
   @html_params  ~s/(\\(#{@html_param}(?:\\s#{@html_param})*?\\))/
   @rest         ~S/(.+)/
 
-  @regex        ~r/(?:#{@indent}|#{@tag_class_id}|#{@hash_params}|#{@html_params}|#{@rest})\s*/
-
+  @regex        ~r/(?:#{@indent}|#{@tag_class_id}|#{@hash_params}|#{@html_params}|#{@rest})/
 
   def tokenize(haml) when is_binary(haml) do
-    Regex.split(~r/\n/, haml, trim: true) |> tokenize |> filter |> tokenize_identation |> index
+    Regex.split(~r/\n/, haml, trim: true) |> tokenize |> tokenize_identation |> index
   end
 
   def tokenize([]), do: []
@@ -22,15 +21,13 @@ defmodule Calliope.Tokenizer do
     [tokenize_line(h) | tokenize(t)]
   end
 
-  defp filter(list), do: Enum.filter(list, fn(x) -> x != [] end)
-
   def tokenize_line(line) do
     Regex.scan(@regex, line, trim: true) |> reduce
   end
 
   def reduce([]), do: []
   def reduce([h|t]) do
-    [List.foldr(h, "", fn(x, acc) -> acc = x end) | reduce(t)]
+    [Enum.reverse(h) |> hd | reduce(t)]
   end
 
   def tokenize_identation(list), do: tokenize_identation(list, compute_tabs(list))

--- a/test/calliope/parser_test.exs
+++ b/test/calliope/parser_test.exs
@@ -91,6 +91,14 @@ defmodule CalliopeParserTest do
     assert parsed_handle_bars == parse handle_bars
   end
 
+  test :parse_with_no_space_after_tag do
+    assert [[attributes: "foo", tag: "h1", line_number: 1]] == parse([[1, "%h1", "(foo)"]])
+  end
+
+  test :parse_with_space_after_tag do
+    assert [[content: "(foo)", tag: "h1", line_number: 1]] == parse([[1, "%h1 ", " (foo)"]])
+  end
+
   test :parse_line do
     each_token_with_index fn({ token, index }) ->
       assert parsed_tokens(index) == parsed_line_tokens(token)

--- a/test/calliope/tokenizer_test.exs
+++ b/test/calliope/tokenizer_test.exs
@@ -30,24 +30,24 @@ defmodule CalliopeTokenizerTest do
 
   test :tokenize_inline_haml do
     inline = "%div Hello Calliope"
-    assert [[1, "%div ","Hello Calliope"]] == tokenize(inline)
-    assert [[1, "%h1 ", "This is \#{title}"]] == tokenize("%h1 This is \#{title}")
+    assert [[1, "%div"," Hello Calliope"]] == tokenize(inline)
+    assert [[1, "%h1", " This is \#{title}"]] == tokenize("%h1 This is \#{title}")
 
     inline = "%a{ng-click: 'doSomething()'}Click Me"
     assert [[1, "%a", "{ng-click: 'doSomething()'}", "Click Me"]] == tokenize inline
 
     inline = "%h1 {{user}}"
-    assert [[1, "%h1 ", "{{user}}"]] == tokenize inline
+    assert [[1, "%h1", " {{user}}"]] == tokenize inline
   end
 
   test :tokenize_multiline_haml do
     assert [
       [1, "!!! 5"],
       [2, "%section", ".container"],
-      [3, "\t", "%h1 ", "Calliope"],
-      [4, "\t", "/ ", "%h1 ", "An important inline comment"],
+      [3, "\t", "%h1", " Calliope"],
+      [4, "\t", "/ ", "%h1", " An important inline comment"],
       [5, "\t", "/[if IE]"],
-      [6, "\t\t", "%h2 ", "An Elixir Haml Parser"],
+      [6, "\t\t", "%h2", " An Elixir Haml Parser"],
       [7, "\t", ".content"],
       [8, "\t\t", "= arg"],
       [9, "\t\t", "Welcome to Calliope"]
@@ -60,27 +60,27 @@ defmodule CalliopeTokenizerTest do
       ] == tokenize(@haml_with_collection)
 
     assert [
-      [1, "%p ", "foo"],
+      [1, "%p", " foo"],
       [2, "\t", "-# This would"],
       [3, "\t\t", "Not be"],
       [4, "\t\t", "output"],
-      [5, "%p ", "bar"]
+      [5, "%p", " bar"]
       ] == tokenize(@haml_with_haml_comments)
   end
 
   test :tokenize_line do
-    assert [[1, "%section", ".container", ".blue", "{src:'#', data:'cool'} ", "Calliope"]] ==
+    assert [[1, "%section", ".container", ".blue", "{src:'#', data:'cool'}", " Calliope"]] ==
       tokenize("\n%section.container.blue{src:'#', data:'cool'} Calliope")
-    assert [[1, "%section", ".container", "(src='#' data='cool') ", "Calliope"]] ==
+    assert [[1, "%section", ".container", "(src='#' data='cool')", " Calliope"]] ==
       tokenize("\n%section.container(src='#' data='cool') Calliope")
-    assert [[1, "\t", "%a", "{href: \"#\"} ", "Learning about \#{title}"]] ==
+    assert [[1, "\t", "%a", "{href: \"#\"}", " Learning about \#{title}"]] ==
       tokenize("\t%a{href: \"#\"} Learning about \#{title}")
 
     # allowing spaces after the attribute values before closing curly brace
-    assert [[1, "%label", ".cl1", "{ for:  'test', class:  ' cl2' } ", "Label" ]] ==
+    assert [[1, "%label", ".cl1", "{ for:  'test', class:  ' cl2' }", " Label" ]] ==
       tokenize("%label.cl1{ for:  'test', class:  ' cl2' } Label")
 
-    assert [[1, "%label", "{ for: \"\#{@id}\", class: \"\#{@class}\" } ", "Label" ]] ==
+    assert [[1, "%label", "{ for: \"\#{@id}\", class: \"\#{@class}\" }", " Label" ]] ==
       tokenize("%label{ for: \"\#{@id}\", class: \"\#{@class}\" } Label")
   end
 
@@ -117,6 +117,15 @@ defmodule CalliopeTokenizerTest do
     assert 2 == compute_tabs [["aa"], ["  ", "aa"]]
     assert 4 == compute_tabs [["aa"], ["    ", "aa"]]
     assert 2 == compute_tabs [["aa"], ["  ", "aa"], ["    ", "aa"]]
+  end
+
+  test :parse_with_space do
+    assert [[1, "%h1", " (foo)"]] == tokenize("%h1 (foo)")
+    assert [[1, "%h1", "(foo)"]] == tokenize("%h1(foo)")
+  end
+
+  test :parse_with_content do
+    assert [[1, "%h1", " foo"]] == tokenize("%h1 foo")
   end
 
 end


### PR DESCRIPTION
Change tokenizer for "%h1 (foo)" to return move the space from the tag
to the content. Update broken test cases for this issue. Changed
Tokenizer.reduce to actual reduce and therefore eliminate the need for
Tokenizer.filter.