### PR TITLE
Refactoring: Suppress warnings about pipe without parens (by Elixir compiler v1.2.0)

### DIFF
--- a/lib/calliope/engine.ex
+++ b/lib/calliope/engine.ex
@@ -55,11 +55,11 @@ defmodule Calliope.Engine do
       end
 
       def content_with_layout(name, args) do
-        content_for(name, args) |> layout_for args
+        content_for(name, args) |> layout_for(args)
       end
 
       def content_for(:none, args) do
-        Keyword.get(args, :yield, "") |> Calliope.Render.eval args
+        Keyword.get(args, :yield, "") |> Calliope.Render.eval(args)
       end
     end
   end
@@ -76,7 +76,7 @@ defmodule Calliope.Engine do
     quote do: unquote files_for(path) |> haml_views |> view_to_function(path)
   end
 
-  def build_path_for(list), do: Enum.filter(list, fn(x) -> is_binary x end) |> Enum.join "/"
+  def build_path_for(list), do: Enum.filter(list, &is_binary/1) |> Enum.join("/")
 
   def eval_path(path) do
     { path, _ } = Code.eval_quoted path

--- a/lib/calliope/safe.ex
+++ b/lib/calliope/safe.ex
@@ -17,7 +17,7 @@ defmodule Calliope.Safe do
     evaluate_script(args, script)
   end
   def eval_safe_script(script, args) do
-    clean args |> evaluate_script script
+    evaluate_script(args, script) |> clean
   end
 
   def evaluate_script(args, script) do

--- a/test/calliope/render_test.exs
+++ b/test/calliope/render_test.exs
@@ -46,8 +46,8 @@ defmodule CalliopeRenderTest do
 
   test :eval do
     result = "<a href='http://example.com'>Example</a>\n"
-    assert result == render "%a{href: 'http://example.com'} Example" |> eval []
-    assert result == render(~s(%a{href: 'http://example.com'}= "Example")) |> eval [conn: []]
+    assert result == eval("%a{href: 'http://example.com'} Example", []) |> render
+    assert result == render(~s(%a{href: 'http://example.com'}= "Example")) |> eval(conn: [])
   end
 
   test :render_with_params do
@@ -75,7 +75,7 @@ defmodule CalliopeRenderTest do
 
   test :case_evaluation do
     haml = ~s{- case @var do
-  -  nil -> 
+  - nil ->
     %p Found nil value
   - other ->
     %p Found other: 


### PR DESCRIPTION
Using elixir compiler 1.2.0 we get the following warnings:
```
lib/calliope/engine.ex:58: warning: you are piping into a function call without parentheses, which may be ambiguous. Please wrap the function you are piping into in parentheses. For example:

    foo 1 |> bar 2 |> baz 3

Should be written as:

    foo(1) |> bar(2) |> baz(3)
```

This PR is just to suppress this kind of warnings.
Thanks in advance!