### PR TITLE
Test/cleanup

### DIFF
--- a/test/calliope/compiler_test.exs
+++ b/test/calliope/compiler_test.exs
@@ -102,7 +102,7 @@ defmodule CalliopeCompilerTest do
       ]
     ]
 
-    assert equivalent_html?(expected, compile(parsed_tokens))
+    assert_equivalent_html(expected, compile(parsed_tokens))
   end
 
   test :compile_with_multiline_script do
@@ -121,7 +121,7 @@ defmodule CalliopeCompilerTest do
       ]
     ]
 
-    assert equivalent_html?(expected, compile(parsed_tokens))
+    assert_equivalent_html(expected, compile(parsed_tokens))
   end
 
   test :compile_with_cond_evaluation do
@@ -142,7 +142,7 @@ defmodule CalliopeCompilerTest do
         [indent: 2, smart_script: "(2 * 2 != 4) ->", children: [[indent: 3, tag: "p", content: "No2"]]],
         [indent: 2, smart_script: "true ->", children: [[indent: 3, tag: "p", content: "Yes"]]]]]]
 
-    assert equivalent_html?(expected, compile(parsed_tokens))
+    assert_equivalent_html(expected, compile(parsed_tokens))
   end
 
   test :compile_with_if_evaluation do
@@ -156,7 +156,7 @@ defmodule CalliopeCompilerTest do
       [indent: 1, smart_script: "if test > 5 do", children: [[indent: 2, tag: "p", content: "No1"]]],
     ]
 
-    assert equivalent_html?(expected, compile(parsed_tokens))
+    assert_equivalent_html(expected, compile(parsed_tokens))
   end
 
   test :compile_with_if_else_evaluation do
@@ -173,7 +173,7 @@ defmodule CalliopeCompilerTest do
       [indent: 1, smart_script: "else", children: [[indent: 2, tag: "p", content: "No2"]]]
     ]
 
-    assert equivalent_html?(expected, compile(parsed_tokens))
+    assert_equivalent_html(expected, compile(parsed_tokens))
   end
 
   test :compile_with_unless_evaluation do
@@ -187,7 +187,7 @@ defmodule CalliopeCompilerTest do
       [indent: 1, smart_script: "unless test > 5 do", children: [[indent: 2, tag: "p", content: "No1"]]],
     ]
 
-    assert equivalent_html?(expected, compile(parsed_tokens))
+    assert_equivalent_html(expected, compile(parsed_tokens))
   end
 
   test :compile_with_unless_else_evaluation do
@@ -204,7 +204,7 @@ defmodule CalliopeCompilerTest do
       [indent: 1, smart_script: "else", children: [[indent: 2, tag: "p", content: "No2"]]]
     ]
 
-    assert equivalent_html?(expected, compile(parsed_tokens))
+    assert_equivalent_html(expected, compile(parsed_tokens))
   end
 
   test :compile_local_variables do
@@ -218,7 +218,7 @@ defmodule CalliopeCompilerTest do
       [script: " test", line_number: 2]
     ]
 
-    assert equivalent_html?(expected, compile(parsed_tokens))
+    assert_equivalent_html(expected, compile(parsed_tokens))
   end
 
   test :preserves_indentation_and_new_lines do
@@ -255,7 +255,7 @@ defmodule CalliopeCompilerTest do
         children: [[line_number: 2, indent: 1, classes: ["test"]]]]
     ]
 
-    assert equivalent_html?(expected, compile(parsed_tokens))
+    assert_equivalent_html(expected, compile(parsed_tokens))
   end
 
   test :render_anonymous_function_parens do
@@ -270,7 +270,7 @@ defmodule CalliopeCompilerTest do
         children: [[line_number: 2, indent: 1, classes: ["test"]]]]
     ]
 
-    assert equivalent_html?(expected, compile(parsed_tokens))
+    assert_equivalent_html(expected, compile(parsed_tokens))
   end
 
   test :render_anonymous_functions_parens_2 do
@@ -285,6 +285,6 @@ defmodule CalliopeCompilerTest do
         children: [[line_number: 2, indent: 1, classes: ["test"]]]]
     ]
 
-    assert equivalent_html?(expected, compile(parsed_tokens))
+    assert_equivalent_html(expected, compile(parsed_tokens))
   end
 end

--- a/test/calliope/compiler_test.exs
+++ b/test/calliope/compiler_test.exs
@@ -4,24 +4,24 @@ defmodule CalliopeCompilerTest do
   import Calliope.Compiler
 
   @ast [
-    [ doctype: "!!! 5" ],
-    [ tag: "section", classes: ["container"], children: [
-        [ indent: 1, tag: "h1", children: [
-            [ indent: 2, script: "arg"]
+    [doctype: "!!! 5"],
+    [tag: "section", classes: ["container"], children: [
+        [indent: 1, tag: "h1", children: [
+            [indent: 2, script: "arg"]
           ]
         ],
-        [ indent: 1, tag: "h1",  comment: "!--", content: "An important inline comment" ],
+        [indent: 1, tag: "h1",  comment: "!--", content: "An important inline comment"],
         [content: "<!--[if IE]> <h2>An Elixir Haml Parser</h2> <![endif]-->",
             indent: 1, line_number: 6],
-        [ indent: 1, id: "main", classes: ["content"], children: [
-            [ indent: 2, content: "Welcome to Calliope" ],
-            [ indent: 2, tag: "br" ]
+        [indent: 1, id: "main", classes: ["content"], children: [
+            [indent: 2, content: "Welcome to Calliope"],
+            [indent: 2, tag: "br"]
           ]
         ],
       ],
     ],
-    [ tag: "section", classes: ["container"], children: [
-        [ indent: 1, tag: "img", attributes: "src='#'"]
+    [tag: "section", classes: ["container"], children: [
+        [indent: 1, tag: "img", attributes: "src='#'"]
       ]
     ]
   ]
@@ -48,15 +48,15 @@ defmodule CalliopeCompilerTest do
             ]]]
 
   @smart_haml_comments [
-      [ tag: "p", content: "foo", children: [
-          [ indent: 1, smart_script: "# This would", children: [
-              [ indent: 2, content: "Not be"],
-              [ indent: 2, content: "output"]
+      [tag: "p", content: "foo", children: [
+          [indent: 1, smart_script: "# This would", children: [
+              [indent: 2, content: "Not be"],
+              [indent: 2, content: "output"]
             ],
           ]
         ]
       ],
-      [ tag: "p", content: "bar"]
+      [tag: "p", content: "bar"]
     ]
 
   test :precompile_content do
@@ -65,18 +65,18 @@ defmodule CalliopeCompilerTest do
 
   test :compile_attributes do
     assert " id=\"foo\" class=\"bar baz\"" ==
-      compile_attributes([ id: "foo", classes: ["bar", "baz"] ])
-    assert " class=\"bar\"" ==  compile_attributes([ classes: ["bar"] ])
-    assert " id=\"foo\"" ==  compile_attributes([ id: "foo"])
+      compile_attributes([id: "foo", classes: ["bar", "baz"]])
+    assert " class=\"bar\"" == compile_attributes([classes: ["bar"]])
+    assert " id=\"foo\"" == compile_attributes([id: "foo"])
   end
 
   test :compile_key do
-    assert " class=\"content\"" == compile_key({ :classes, ["content"] })
-    assert " id=\"foo\"" == compile_key({ :id, "foo" })
+    assert " class=\"content\"" == compile_key({:classes, ["content"]})
+    assert " id=\"foo\"" == compile_key({:id, "foo"})
   end
 
   test :tag do
-    refute tag([ foo: "bar" ])
+    refute tag([foo: "bar"])
     assert "div" == tag([tag: "div"])
     assert "div" == tag([id: "foo"])
     assert "div" == tag([classes: ["bar"]])
@@ -86,7 +86,7 @@ defmodule CalliopeCompilerTest do
   end
 
   test :open do
-    assert "<div>"     == open("", :div)
+    assert "<div>" == open("", :div)
     assert "<section>" == open("", :section)
     assert "" == open("", nil)
 
@@ -125,9 +125,9 @@ defmodule CalliopeCompilerTest do
       <% end %>}, "")
 
     parsed_tokens = [
-      [ indent: 1, tag: "h1", content: "Calliope"],
-      [ indent: 1, smart_script: "for a <- b do", children: [
-          [ indent: 2, tag: "div", script: "a"]
+      [indent: 1, tag: "h1", content: "Calliope"],
+      [indent: 1, smart_script: "for a <- b do", children: [
+          [indent: 2, tag: "div", script: "a"]
         ]
       ]
     ]
@@ -149,10 +149,10 @@ defmodule CalliopeCompilerTest do
       <% end %>}, "")
 
     parsed_tokens = [
-      [ indent: 1, smart_script: "cond do", children: [
-        [ indent: 2, smart_script: "(1 + 1 == 1) ->", children: [[ indent: 3, tag: "p", content: "No1" ]]],
-        [ indent: 2, smart_script: "(2 * 2 != 4) ->", children: [[ indent: 3, tag: "p", content: "No2" ]]],
-        [ indent: 2, smart_script: "true ->", children: [[ indent: 3, tag: "p", content: "Yes" ]]]]]]
+      [indent: 1, smart_script: "cond do", children: [
+        [indent: 2, smart_script: "(1 + 1 == 1) ->", children: [[indent: 3, tag: "p", content: "No1"]]],
+        [indent: 2, smart_script: "(2 * 2 != 4) ->", children: [[indent: 3, tag: "p", content: "No2"]]],
+        [indent: 2, smart_script: "true ->", children: [[indent: 3, tag: "p", content: "Yes"]]]]]]
 
     compiled_results = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, compile(parsed_tokens), "")
 
@@ -166,7 +166,7 @@ defmodule CalliopeCompilerTest do
       <% end %>}, "")
 
     parsed_tokens = [
-      [ indent: 1, smart_script: "if test > 5 do", children: [[ indent: 2, tag: "p", content: "No1" ]]],
+      [indent: 1, smart_script: "if test > 5 do", children: [[indent: 2, tag: "p", content: "No1"]]],
     ]
     compiled_results = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, compile(parsed_tokens), "")
 
@@ -182,8 +182,8 @@ defmodule CalliopeCompilerTest do
       <% end %>}, "")
 
     parsed_tokens = [
-      [ indent: 1, smart_script: "if test > 5 do", children: [[ indent: 2, tag: "p", content: "No1" ]]],
-      [ indent: 1, smart_script: "else", children: [[indent: 2, tag: "p", content: "No2" ]]]
+      [indent: 1, smart_script: "if test > 5 do", children: [[indent: 2, tag: "p", content: "No1"]]],
+      [indent: 1, smart_script: "else", children: [[indent: 2, tag: "p", content: "No2"]]]
     ]
     compiled_results = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, compile(parsed_tokens), "")
 
@@ -197,7 +197,7 @@ defmodule CalliopeCompilerTest do
       <% end %>}, "")
 
     parsed_tokens = [
-      [ indent: 1, smart_script: "unless test > 5 do", children: [[ indent: 2, tag: "p", content: "No1" ]]],
+      [indent: 1, smart_script: "unless test > 5 do", children: [[indent: 2, tag: "p", content: "No1"]]],
     ]
     compiled_results = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, compile(parsed_tokens), "")
 
@@ -212,8 +212,8 @@ defmodule CalliopeCompilerTest do
 <% end %>}
 
     parsed_tokens = [
-      [ indent: 1, smart_script: "unless test > 5 do", children: [[ indent: 2, tag: "p", content: "No1" ]]],
-      [ indent: 1, smart_script: "else", children: [[indent: 2, tag: "p", content: "No2" ]]]
+      [indent: 1, smart_script: "unless test > 5 do", children: [[indent: 2, tag: "p", content: "No1"]]],
+      [indent: 1, smart_script: "else", children: [[indent: 2, tag: "p", content: "No2"]]]
     ]
     compiled_results = compile(parsed_tokens)
     assert expected_results == compiled_results
@@ -227,7 +227,7 @@ defmodule CalliopeCompilerTest do
     parsed_tokens = [
       [smart_script: "test = \"testing\"", line_number: 1],
       [script: " test", line_number: 2]
-    ] 
+    ]
     compiled_results = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, compile(parsed_tokens), "")
     assert expected_results == compiled_results
   end
@@ -235,17 +235,17 @@ defmodule CalliopeCompilerTest do
   test :preserves_indentation_and_new_lines do
     expected = "  <div>\n    <b>Test</b>\n  </div>\n"
     parsed_tokens = [
-      [ indent: 1, tag: "div", line_number: 1, children: [
-          [ indent: 2, tag: "b", content: "Test", line_number: 2]
+      [indent: 1, tag: "div", line_number: 1, children: [
+          [indent: 2, tag: "b", content: "Test", line_number: 2]
         ]
       ]
     ]
     assert expected == compile(parsed_tokens)
   end
-  
+
   test :preserves_indentation_and_new_lines_2 do
     expected = "<div class=\"simple_div\">\n  <b>Label:</b>\n  Content\n</div>\nOutside the div\n"
-    parsed_tokens = [[ line_number: 1, classes: ["simple_div"], children: [
+    parsed_tokens = [[line_number: 1, classes: ["simple_div"], children: [
       [content: "Label:", tag: "b", indent: 1, line_number: 2],
       [content: "Content", indent: 1, line_number: 3]]],
       [content: "Outside the div", line_number: 4]]

--- a/test/calliope/compiler_test.exs
+++ b/test/calliope/compiler_test.exs
@@ -2,62 +2,7 @@ defmodule CalliopeCompilerTest do
   use ExUnit.Case
 
   import Calliope.Compiler
-
-  @ast [
-    [doctype: "!!! 5"],
-    [tag: "section", classes: ["container"], children: [
-        [indent: 1, tag: "h1", children: [
-            [indent: 2, script: "arg"]
-          ]
-        ],
-        [indent: 1, tag: "h1",  comment: "!--", content: "An important inline comment"],
-        [content: "<!--[if IE]> <h2>An Elixir Haml Parser</h2> <![endif]-->",
-            indent: 1, line_number: 6],
-        [indent: 1, id: "main", classes: ["content"], children: [
-            [indent: 2, content: "Welcome to Calliope"],
-            [indent: 2, tag: "br"]
-          ]
-        ],
-      ],
-    ],
-    [tag: "section", classes: ["container"], children: [
-        [indent: 1, tag: "img", attributes: "src='#'"]
-      ]
-    ]
-  ]
-
-  @html ~s{<!DOCTYPE html>
-<section class="container">
-  <h1>
-    <%= arg %>
-  </h1>
-  <!-- <h1>An important inline comment</h1> -->
-  <!--[if IE]> <h2>An Elixir Haml Parser</h2> <![endif]-->
-  <div id="main" class="content">
-    Welcome to Calliope
-    <br>
-  </div>
-</section>
-<section class="container">
-  <img src='#'>
-</section>
-}
-
-  @smart [[smart_script: "for { id, content } <- posts do", children: [
-              [indent: 1, tag: "div", children: [[indent: 2, script: "content"]]]
-            ]]]
-
-  @smart_haml_comments [
-      [tag: "p", content: "foo", children: [
-          [indent: 1, smart_script: "# This would", children: [
-              [indent: 2, content: "Not be"],
-              [indent: 2, content: "output"]
-            ],
-          ]
-        ]
-      ],
-      [tag: "p", content: "bar"]
-    ]
+  import Support.EquivalentHtml
 
   test :precompile_content do
     assert "Hello <%= name %>" == precompile_content("Hello \#{name}")
@@ -105,7 +50,7 @@ defmodule CalliopeCompilerTest do
     assert "" == close("link")
   end
 
-  test :compile do
+  test :compile_simple_tags do
      assert ~s{<div id="test"></div>\n} == compile([[id: "test"]])
      assert ~s{<section id="test" class="content"></section>\n} == compile([[tag: "section", id: "test", classes: ["content"]]])
 
@@ -113,16 +58,60 @@ defmodule CalliopeCompilerTest do
      assert ~s{<div id="test">\n<div class="nested"></div>\n</div>\n} == compile([[id: "test", children: children]])
 
      assert ~s{content} <> "\n" == compile([[content: "content"]])
+  end
 
-     assert @html == compile(@ast)
+  test :compile_document do
+    expected = """
+      <!DOCTYPE html>
+      <section class="container">
+        <h1>
+          <%= arg %>
+        </h1>
+        <!-- <h1>An important inline comment</h1> -->
+        <!--[if IE]> <h2>An Elixir Haml Parser</h2> <![endif]-->
+        <div id="main" class="content">
+          Welcome to Calliope
+          <br>
+        </div>
+      </section>
+      <section class="container">
+        <img src='#'>
+      </section>
+      """
+
+    parsed_tokens = [
+      [doctype: "!!! 5"],
+      [tag: "section", classes: ["container"], children: [
+          [indent: 1, tag: "h1", children: [
+              [indent: 2, script: "arg"]
+            ]
+          ],
+          [indent: 1, tag: "h1",  comment: "!--", content: "An important inline comment"],
+          [content: "<!--[if IE]> <h2>An Elixir Haml Parser</h2> <![endif]-->",
+              indent: 1, line_number: 6],
+          [indent: 1, id: "main", classes: ["content"], children: [
+              [indent: 2, content: "Welcome to Calliope"],
+              [indent: 2, tag: "br"]
+            ]
+          ],
+        ],
+      ],
+      [tag: "section", classes: ["container"], children: [
+          [indent: 1, tag: "img", attributes: "src='#'"]
+        ]
+      ]
+    ]
+
+    assert equivalent_html?(expected, compile(parsed_tokens))
   end
 
   test :compile_with_multiline_script do
-    expected_results = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, ~s{
+    expected = """
       <h1>Calliope</h1>
       <%= for a <- b do %>
         <div><%= a %></div>
-      <% end %>}, "")
+      <% end %>
+      """
 
     parsed_tokens = [
       [indent: 1, tag: "h1", content: "Calliope"],
@@ -132,13 +121,11 @@ defmodule CalliopeCompilerTest do
       ]
     ]
 
-    compiled_results = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, compile(parsed_tokens), "")
-
-    assert expected_results == compiled_results
+    assert equivalent_html?(expected, compile(parsed_tokens))
   end
 
   test :compile_with_cond_evaluation do
-    expected_results = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, ~s{
+    expected = """
       <%= cond do %>
         <% (1 + 1 == 1) -> %>
           <p>No1</p>
@@ -146,7 +133,8 @@ defmodule CalliopeCompilerTest do
           <p>No2</p>
         <% true -> %>
           <p>Yes</p>
-      <% end %>}, "")
+      <% end %>
+      """
 
     parsed_tokens = [
       [indent: 1, smart_script: "cond do", children: [
@@ -154,82 +142,83 @@ defmodule CalliopeCompilerTest do
         [indent: 2, smart_script: "(2 * 2 != 4) ->", children: [[indent: 3, tag: "p", content: "No2"]]],
         [indent: 2, smart_script: "true ->", children: [[indent: 3, tag: "p", content: "Yes"]]]]]]
 
-    compiled_results = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, compile(parsed_tokens), "")
-
-    assert expected_results == compiled_results
+    assert equivalent_html?(expected, compile(parsed_tokens))
   end
 
   test :compile_with_if_evaluation do
-    expected_results = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, ~s{
+    expected = """
       <%= if test > 5 do %>
          <p>No1</p>
-      <% end %>}, "")
+      <% end %>
+      """
 
     parsed_tokens = [
       [indent: 1, smart_script: "if test > 5 do", children: [[indent: 2, tag: "p", content: "No1"]]],
     ]
-    compiled_results = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, compile(parsed_tokens), "")
 
-    assert expected_results == compiled_results
+    assert equivalent_html?(expected, compile(parsed_tokens))
   end
 
   test :compile_with_if_else_evaluation do
-    expected_results = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, ~s{
+    expected = """
       <%= if test > 5 do %>
          <p>No1</p>
       <% else %>
          <p>No2</p>
-      <% end %>}, "")
+      <% end %>
+      """
 
     parsed_tokens = [
       [indent: 1, smart_script: "if test > 5 do", children: [[indent: 2, tag: "p", content: "No1"]]],
       [indent: 1, smart_script: "else", children: [[indent: 2, tag: "p", content: "No2"]]]
     ]
-    compiled_results = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, compile(parsed_tokens), "")
 
-    assert expected_results == compiled_results
+    assert equivalent_html?(expected, compile(parsed_tokens))
   end
 
   test :compile_with_unless_evaluation do
-    expected_results = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, ~s{
+    expected = """
       <%= unless test > 5 do %>
          <p>No1</p>
-      <% end %>}, "")
+      <% end %>
+      """
 
     parsed_tokens = [
       [indent: 1, smart_script: "unless test > 5 do", children: [[indent: 2, tag: "p", content: "No1"]]],
     ]
-    compiled_results = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, compile(parsed_tokens), "")
 
-    assert expected_results == compiled_results
+    assert equivalent_html?(expected, compile(parsed_tokens))
   end
 
   test :compile_with_unless_else_evaluation do
-    expected_results = ~s{<%= unless test > 5 do %>
-  <p>No1</p>
-<% else %>
-  <p>No2</p>
-<% end %>}
+    expected = """
+      <%= unless test > 5 do %>
+        <p>No1</p>
+      <% else %>
+        <p>No2</p>
+      <% end %>
+      """
 
     parsed_tokens = [
       [indent: 1, smart_script: "unless test > 5 do", children: [[indent: 2, tag: "p", content: "No1"]]],
       [indent: 1, smart_script: "else", children: [[indent: 2, tag: "p", content: "No2"]]]
     ]
-    compiled_results = compile(parsed_tokens)
-    assert expected_results == compiled_results
+
+    assert equivalent_html?(expected, compile(parsed_tokens))
   end
 
   test :compile_local_variables do
-    expected_results = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, ~s{
+    expected = """
       <% test = "testing" %>
-      <%= test %>}, "")
+      <%= test %>
+      """
 
     parsed_tokens = [
       [smart_script: "test = \"testing\"", line_number: 1],
       [script: " test", line_number: 2]
     ]
-    compiled_results = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, compile(parsed_tokens), "")
-    assert expected_results == compiled_results
+
+    assert equivalent_html?(expected, compile(parsed_tokens))
   end
 
   test :preserves_indentation_and_new_lines do
@@ -240,6 +229,7 @@ defmodule CalliopeCompilerTest do
         ]
       ]
     ]
+
     assert expected == compile(parsed_tokens)
   end
 
@@ -249,45 +239,52 @@ defmodule CalliopeCompilerTest do
       [content: "Label:", tag: "b", indent: 1, line_number: 2],
       [content: "Content", indent: 1, line_number: 3]]],
       [content: "Outside the div", line_number: 4]]
+
     assert compile(parsed_tokens) == expected
   end
 
-  @expected ~s[<%= form_for @changeset, @action, fn f -> %>
-<div class=\"test\"></div>
-
-<% end %>]
-
   test :render_anonymous_functions do
+    expected = """
+      <%= form_for @changeset, @action, fn f -> %>
+        <div class=\"test\"></div>
+      <% end %>
+      """
+
     parsed_tokens = [
       [smart_script: "form_for @changeset, @action, fn f ->", line_number: 1,
         children: [[line_number: 2, indent: 1, classes: ["test"]]]]
     ]
-    assert compile(parsed_tokens) == @expected
+
+    assert equivalent_html?(expected, compile(parsed_tokens))
   end
 
-  @expected ~s[<%= form_for @changeset, @action, fn(f) -> %>
-<div class=\"test\"></div>
-
-<% end %>]
-
   test :render_anonymous_function_parens do
+    expected = """
+      <%= form_for @changeset, @action, fn(f) -> %>
+        <div class=\"test\"></div>
+      <% end %>
+      """
+
     parsed_tokens = [
       [smart_script: "form_for @changeset, @action, fn(f) ->", line_number: 1,
         children: [[line_number: 2, indent: 1, classes: ["test"]]]]
     ]
-    assert compile(parsed_tokens) == @expected
+
+    assert equivalent_html?(expected, compile(parsed_tokens))
   end
 
-  @expected ~s[<%= form_for(@changeset, @action, fn(f) -> %>
-<div class=\"test\"></div>
-
-<% end) %>]
-
   test :render_anonymous_functions_parens_2 do
+    expected = """
+      <%= form_for(@changeset, @action, fn(f) -> %>
+        <div class=\"test\"></div>
+      <% end) %>
+      """
+
     parsed_tokens = [
       [smart_script: "form_for(@changeset, @action, fn(f) ->", line_number: 1,
         children: [[line_number: 2, indent: 1, classes: ["test"]]]]
     ]
-    assert compile(parsed_tokens) == @expected
+
+    assert equivalent_html?(expected, compile(parsed_tokens))
   end
 end

--- a/test/calliope/render_test.exs
+++ b/test/calliope/render_test.exs
@@ -2,46 +2,52 @@ defmodule CalliopeRenderTest do
   use ExUnit.Case
 
   use Calliope.Render
+  import Support.EquivalentHtml
 
-  @haml ~s{!!! 5
-%section.container(class= "blue" style="margin-top: 10px" data-value=@value)
-  %article
-    %h1= title
-    :javascript
-      var x = 5;
-      var y = 10;
-    / %h1 An important inline comment
-    /[if IE]
-      %h2 An Elixir Haml Parser
-    %label.cl1\{ for:  "test", class: " cl2"  \} Label
-    #main.content
-      Welcome to Calliope}
-
-  @html ~s{<!DOCTYPE html>
-<section class="container blue" style="margin-top: 10px" data-value='<%= @value %>'>
-  <article>
-    <h1><%= title %></h1>
-    <script type="text/javascript">
-      var x = 5;
-      var y = 10;
-    </script>
-    <!-- <h1>An important inline comment</h1> -->
-    <!--[if IE]>       <h2>An Elixir Haml Parser</h2> <![endif]-->
-    <label class="cl1 cl2" for="test">Label</label>
-    <div id="main" class="content">
-      Welcome to Calliope
-    </div>
-  </article>
-</section>
-}
-
-  @haml_with_args "%a{href: '#\{url}'}= title"
+  def haml_with_args, do: "%a{href: '#\{url}'}= title"
 
   test :render do
-    assert String.replace(@html, "\n", "") == String.replace(render(@haml), "\n", "")
     assert "<h1>This is <%= title %></h1>\n" == render "%h1 This is \#{title}"
     assert "<a ng-click='doSomething()'>Click Me</a>\n" == render "%a{ng-click: 'doSomething()'} Click Me"
     assert "<h1>{{user}}</h1>\n" == render "%h1 {{user}}"
+  end
+
+  test :render_document do
+    expected = """
+      <!DOCTYPE html>
+      <section class="container blue" style="margin-top: 10px" data-value='<%= @value %>'>
+        <article>
+          <h1><%= title %></h1>
+          <script type="text/javascript">
+            var x = 5;
+            var y = 10;
+          </script>
+          <!-- <h1>An important inline comment</h1> -->
+          <!--[if IE]><h2>An Elixir Haml Parser</h2><![endif]-->
+          <label class="cl1 cl2" for="test">Label</label>
+          <div id="main" class="content">
+            Welcome to Calliope
+          </div>
+        </article>
+      </section>
+      """
+
+    haml = """
+      !!! 5
+      %section.container(class= "blue" style="margin-top: 10px" data-value=@value)
+        %article
+          %h1= title
+          :javascript
+            var x = 5;
+            var y = 10;
+          / %h1 An important inline comment
+          /[if IE]
+            %h2 An Elixir Haml Parser
+          %label.cl1\{ for:  "test", class: " cl2"  \} Label
+          #main.content
+            Welcome to Calliope
+      """
+    assert equivalent_html?(expected, render(haml))
   end
 
   test :eval do
@@ -52,55 +58,61 @@ defmodule CalliopeRenderTest do
 
   test :render_with_params do
     assert "<a href='<%= url %>'><%= title %></a>\n" ==
-      render @haml_with_args
+      render haml_with_args
   end
 
   test :render_with_args do
     assert "<a href='http://google.com'>Google</a>\n" ==
-      render @haml_with_args, [ url: "http://google.com", title: "Google" ]
+      render haml_with_args, [ url: "http://google.com", title: "Google" ]
   end
 
   test :local_variable do
-
-    expected = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, ~s{
+    expected = """
       <% var = "test" %>
-      <p><%= var %></p>}, "")
+      <p><%= var %></p>
+      """
 
     haml = """
-- var = "test"
-%p= var
-"""
-    assert expected == Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, render(haml), "")
+      - var = "test"
+      %p= var
+      """
+
+    assert equivalent_html?(expected, render(haml))
   end
 
   test :case_evaluation do
-    haml = ~s{- case @var do
-  -  nil -> 
-    %p Found nil value
-  - other ->
-    %p Found other: 
-      = other
-}
+    expected = """
+      <%= case @var do %>
+      <% nil -> %>
+      <p>Found nil value</p>
+      <% other -> %>
+      <p>
+      Found other:  <%= other %>
+      </p>
 
-    expected = ~s{<%= case @var do %>
-<% nil -> %>
-<p>Found nil value</p>
-<% other -> %>
-<p>Found other:
-  <%= other %></p>
-<% end %>
-}
-    assert String.replace(expected, "\n", "") == String.replace(render(haml), "\n", "")
+      <% end %>
+      """
+
+    haml = """
+      - case @var do
+        -  nil ->
+          %p Found nil value
+        - other ->
+          %p Found other:
+            = other
+      """
+
+    assert equivalent_html?(expected, render(haml))
   end
 
   test :else_result do
     haml = """
-- if false do
-  %p true
-- else 
-  %p false
-"""
-    actual = Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, EEx.eval_string(render(haml), []), "")
-    assert actual == "<p>false</p>" 
+      - if false do
+        %p true
+      - else
+        %p false
+      """
+
+    assert equivalent_html?("<p>false</p>", EEx.eval_string(render(haml), []))
   end
 end

--- a/test/calliope/render_test.exs
+++ b/test/calliope/render_test.exs
@@ -47,7 +47,7 @@ defmodule CalliopeRenderTest do
           #main.content
             Welcome to Calliope
       """
-    assert equivalent_html?(expected, render(haml))
+    assert_equivalent_html(expected, render(haml))
   end
 
   test :eval do
@@ -77,7 +77,7 @@ defmodule CalliopeRenderTest do
       %p= var
       """
 
-    assert equivalent_html?(expected, render(haml))
+    assert_equivalent_html(expected, render(haml))
   end
 
   test :case_evaluation do
@@ -102,7 +102,7 @@ defmodule CalliopeRenderTest do
             = other
       """
 
-    assert equivalent_html?(expected, render(haml))
+    assert_equivalent_html(expected, render(haml))
   end
 
   test :else_result do
@@ -113,6 +113,6 @@ defmodule CalliopeRenderTest do
         %p false
       """
 
-    assert equivalent_html?("<p>false</p>", EEx.eval_string(render(haml), []))
+    assert_equivalent_html("<p>false</p>", EEx.eval_string(render(haml), []))
   end
 end

--- a/test/support/equivalent_html.exs
+++ b/test/support/equivalent_html.exs
@@ -1,6 +1,8 @@
 defmodule Support.EquivalentHtml do
-  def equivalent_html?(html1, html2) do
-    stripped(html1) == stripped(html2)
+  import ExUnit.Assertions, only: [assert: 1, assert: 2]
+
+  def assert_equivalent_html(html1, html2) do
+    assert(stripped(html1) == stripped(html2))
   end
 
   defp stripped(html) do

--- a/test/support/equivalent_html.exs
+++ b/test/support/equivalent_html.exs
@@ -1,0 +1,9 @@
+defmodule Support.EquivalentHtml do
+  def equivalent_html?(html1, html2) do
+    stripped(html1) == stripped(html2)
+  end
+
+  defp stripped(html) do
+    Regex.replace(~r/(^\s*)|(\s+$)|(\n)/m, html, "")
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
+Code.load_file("equivalent_html.exs", "./test/support")
+
 ExUnit.start


### PR DESCRIPTION
Some cleanup of tests in the compiler/renderer. I've created an equivalent html assertion (`assert_equivalent_html`).

The helper can lead to this gotcha with mid-line white space:

```elixir
html1 = "<h1>Hello</h1>           <p>Elixir is fun</p>"
html2 = "<h1>Hello</h1><p>Elixir is fun</p>"
assert_equivalent_html(html1, html2) #=> test failure
```

The resulting test failure provides a helpful message though:

```iex
  1) test equivalent_html_helper (CalliopeCompilerTest)
     test/calliope/compiler_test.exs:11
     Assertion with == failed
     code: stripped(html1) == stripped(html2)
     lhs:  "<h1>Hello</h1>           <p>Elixir is fun</p>"
     rhs:  "<h1>Hello</h1><p>Elixir is fun</p>"
     stacktrace:
       test/calliope/compiler_test.exs:14
```
