### PR TITLE
Updating deprecated regex syntax by replacing `/r` (ungreedy) with `/U`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: elixir
 elixir:
-  - 1.0
+  - 1.3
 otp_release:
-  - 17.0
+  - 18.0

--- a/lib/calliope/compile.ex
+++ b/lib/calliope/compile.ex
@@ -28,12 +28,12 @@ defmodule Calliope.Compiler do
   end
   defp build_html(node, [next_node|_], si) do
     cond do
-      node[:smart_script] -> 
+      node[:smart_script] ->
         cond do
           next_node[:smart_script] ->
             # send next code to look ahead for things like else
             evaluate_smart_script(node[:smart_script], node[:children], next_node[:smart_script], si)
-          true ->  
+          true ->
             evaluate_smart_script(node[:smart_script], node[:children], "", si)
         end
       true -> evaluate(node, si)
@@ -112,7 +112,7 @@ defmodule Calliope.Compiler do
 
   def precompile_content(nil), do: nil
   def precompile_content(content) do
-    Regex.scan(~r/\#{(.+)}/r, content) |>
+    Regex.scan(~r/\#{(.+)}/U, content) |>
       map_content_to_args(content)
   end
 
@@ -170,7 +170,7 @@ defmodule Calliope.Compiler do
     cond do
       Regex.match? ~r/(fn )|(fn\()[a-zA-Z0-9,\) ]+->/, script ->
         %{cmd: script, wraps_end: "<% end#{ch} %>", end_tag: "%>", open_tag: "<%="}
-      Regex.match? ~r/ do:?/, script -> 
+      Regex.match? ~r/ do:?/, script ->
         %{cmd: script, wraps_end: "<% end#{ch} %>", end_tag: "%>", open_tag: "<%="}
       true ->
         %{cmd: script, wraps_end: "", end_tag: "%>", open_tag: "<%"}

--- a/lib/calliope/parser.ex
+++ b/lib/calliope/parser.ex
@@ -62,8 +62,8 @@ defmodule Calliope.Parser do
 
   def build_attributes(value) do
     String.slice(value, 0, String.length(value)-1) |>
-      String.replace(~r/(?<![-_])class[=:]\s?['"](.*)['"]/r, "") |>
-      String.replace(~r/(?<![-_])id[=:]\s?['"](.*)['"]/r, "") |>
+      String.replace(~r/(?<![-_])class[=:]\s?['"](.*)['"]/U, "") |>
+      String.replace(~r/(?<![-_])id[=:]\s?['"](.*)['"]/U, "") |>
       String.replace(~r/:\s+([\'"])/, "=\\1") |>
       String.replace(~r/[:=]\s?(?!.*["'])(@?\w+)\s?/, "='#\{\\1}'") |>
       String.replace(~r/[})]$/, "") |>
@@ -82,7 +82,7 @@ defmodule Calliope.Parser do
   def validate_attributes(attributes) do
     if Regex.match?(~r/#{@validate}/, attributes) || attributes == "" do
       {:ok, attributes}
-    else 
+    else
       {:error, attributes}
     end
   end
@@ -131,9 +131,9 @@ defmodule Calliope.Parser do
     classes = extract(:class, value)
     id = extract(:id, value)
     attributes = case build_attributes(value) |> validate_attributes do
-      {:ok, attrs}    -> 
+      {:ok, attrs}    ->
         attrs
-      {:error, attrs} -> 
+      {:error, attrs} ->
         raise_error :invalid_attribute, list[:line_number], attrs
     end
 
@@ -142,7 +142,7 @@ defmodule Calliope.Parser do
 
   defp extract(_, nil), do: []
   defp extract(key, str) do
-    case Regex.run(~r/(?<![-_])#{key}[=:]\s?['"](.*)['"]/r, str) do
+    case Regex.run(~r/(?<![-_])#{key}[=:]\s?['"](.*)['"]/U, str) do
       [ _, match | _ ] -> String.split match
       _ -> []
     end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Calliope.Mixfile do
   def project do
     [ app: :calliope,
       version: "0.4.0",
-      elixir: ">= 1.0.0",
+      elixir: "~> 1.3.0",
       deps: [],
       package: [
         files: ["lib", "mix.exs", "README*", "LICENSE*"],


### PR DESCRIPTION
Regex option for ungreedy match `~r/.../r` was deprecated and is replaced with `~r/.../U` in [Elixir 1.3](https://github.com/elixir-lang/elixir/releases/tag/v1.3.0) which generates quite a few warnings.