### PR TITLE
Add optional escaping to interpolated values

### DIFF
--- a/lib/calliope/render.ex
+++ b/lib/calliope/render.ex
@@ -2,13 +2,28 @@ defmodule Calliope.Render do
   import Calliope.Tokenizer
   import Calliope.Parser
   import Calliope.Compiler
+  import Calliope.Safe
 
   def precompile(haml) do
     tokenize(haml) |> parse |> compile
   end
 
   def eval(html, []), do: html
-  def eval(html, args), do: EEx.eval_string(html, args)
+  def eval(html, args), do: EEx.eval_string(html, maybe_escape(args))
+
+  defp maybe_escape(args) do
+    cond do
+      args[:_safe] ->
+        Enum.map(
+          args,
+          fn {k, v} when is_binary(v) -> {k, clean(v) }
+             {k, v} -> {k, v}
+          end
+        )
+      true ->
+        args
+    end
+  end
 
   defmacro __using__([]) do
     quote do

--- a/test/calliope/engine_test.exs
+++ b/test/calliope/engine_test.exs
@@ -23,6 +23,10 @@ defmodule CalliopeEngineTest do
     assert "<h1>Calliope</h1>\nIndex Page\n" == content_for :index, [title: "Calliope"]
   end
 
+  test :render_pages_with_dangerous_values do
+    assert "<h1>&lt;script&rt;Calliope&lt;/script&rt;</h1>\nIndex Page\n" == content_for :index, [title: "<script>Calliope</script>", _safe: true]
+  end
+
   test :content_for_multiple_views do
     assert "This is the edit page\n" == content_for :edit, []
     assert "This is the show page\n" == content_for :show, []


### PR DESCRIPTION
Please feel free to push me in the direction of something more idiomatic if this isn't working, I'm pretty new to Elixir.

I have a need for auto escaping of interpolated values. As mentioned by https://github.com/nurugger07/calliope/issues/24. In my opinion one advantage of templating libraries is taking care of those kinds of problems. It might even be a good idea for this to be a default 💭 

Thanks!