### PR TITLE
Remove necessity for interpolation in attributes

### DIFF
--- a/lib/calliope/tokenizer.ex
+++ b/lib/calliope/tokenizer.ex
@@ -25,6 +25,22 @@ defmodule Calliope.Tokenizer do
 
   def tokenize_line(line) do
     Regex.scan(@regex, line, trim: true) |> reduce
+    |> Enum.map(fn(t) ->
+      s = String.split(t, ~r/(}|\))\s*=/)
+      case s do
+        [tag, content] -> [tag <> "}", "=" <> content]
+        _ -> s
+      end
+    end)
+    |> List.flatten
+    |> Enum.map(fn(t) ->
+      s = String.split(t, ~r/(}|\))\s+/)
+      case s do
+        [tag, content] -> [tag <> "}", " " <> content]
+        _ -> s
+      end
+    end)
+    |> List.flatten
   end
 
   def reduce([]), do: []

--- a/lib/calliope/tokenizer.ex
+++ b/lib/calliope/tokenizer.ex
@@ -34,10 +34,14 @@ defmodule Calliope.Tokenizer do
     end)
     |> List.flatten
     |> Enum.map(fn(t) ->
-      s = String.split(t, ~r/(}|\))\s+/)
-      case s do
-        [tag, content] -> [tag <> "}", " " <> content]
-        _ -> s
+      case String.starts_with?(t, "-") do
+        false ->
+          s = String.split(t, ~r/(}|\))\s+/i)
+          case s do
+            [tag, content] -> [tag <> "}", " " <> content]
+            _ -> s
+          end
+        true -> t
       end
     end)
     |> List.flatten

--- a/test/calliope/render_test.exs
+++ b/test/calliope/render_test.exs
@@ -5,6 +5,9 @@ defmodule CalliopeRenderTest do
   import Support.EquivalentHtml
 
   def haml_with_args, do: "%a{href: '#\{url}'}= title"
+  def haml_with_unin_args, do: "%a{href: url}= title"
+  def haml_with_unin_args_content_only, do: "%a{href: url} title"
+  def haml_with_unin_parens, do: "%a(href=url)= title"
 
   test :render do
     assert "<h1>This is <%= title %></h1>\n" == render "%h1 This is \#{title}"
@@ -50,6 +53,17 @@ defmodule CalliopeRenderTest do
     assert_equivalent_html(expected, render(haml))
   end
 
+  test :render_indented_plain_args do
+    expected = """
+      <a href='http://foobar.com'>Text</a>
+      """
+
+    haml = """
+      %a{href: url} Text
+      """
+    assert_equivalent_html(expected, render(haml, [url: 'http://foobar.com']))
+  end
+
   test :eval do
     result = "<a href='http://example.com'>Example</a>\n"
     assert result == render "%a{href: 'http://example.com'} Example" |> eval([])
@@ -64,6 +78,21 @@ defmodule CalliopeRenderTest do
   test :render_with_args do
     assert "<a href='http://google.com'>Google</a>\n" ==
       render haml_with_args, [ url: "http://google.com", title: "Google" ]
+  end
+
+  test :render_with_unin_args do
+    assert "<a href='http://google.com'>Google</a>\n" ==
+      render haml_with_unin_args, [ url: "http://google.com", title: "Google" ]
+  end
+
+  test :render_with_unin_args_content_only do
+    assert "<a href='http://google.com'>title</a>\n" ==
+      render haml_with_unin_args_content_only, [ url: "http://google.com" ]
+  end
+
+  test :render_with_unin_parens do
+    assert "<a href='http://google.com'>Google</a>\n" ==
+      render haml_with_unin_parens, [ url: "http://google.com", title: "Google" ]
   end
 
   test :local_variable do


### PR DESCRIPTION
I looked into the interpolation of attributes and got a PoC now that seems to work.

I added a few more tests because there were quite a few edge cases.

@smpallen99  Could you maybe check this out and try if there are any edge cases I might have missed? After we figure that out I'll happily refactor the code and make it more elegant - it is a bit of a mess right now ;-).