### PR TITLE
Slightly improves HAML attribute parsing

### DIFF
--- a/lib/calliope/parser.ex
+++ b/lib/calliope/parser.ex
@@ -68,12 +68,13 @@ defmodule Calliope.Parser do
       String.replace(~r/(?<![-_])class[=:]\s?['"](.*)['"]/U, "") |>
       String.replace(~r/(?<![-_])id[=:]\s?['"](.*)['"]/U, "") |>
       String.replace(~r/:\s+([\'"])/, "=\\1") |>
-      String.replace(~r/[:=]\s?(?!.*["'])(@?\w+)\s?/, "='#\{\\1}'") |>
+      String.replace(~r/[:=]\s?(?!.*["'])(@?[\w\.]+)\s?/, "='#\{\\1}'") |>
       String.replace(~r/[})]$/, "") |>
       String.replace(~r/"(.+?)"\s=>\s(@?\w+)\s?/, "\\1='#\{\\2}'") |>
       String.replace(~r/:(.+?)\s=>\s['"](.*)['"]\s?/, "\\1='\\2'") |>
       filter_commas |>
-      String.strip
+      String.strip |>
+      IO.inspect
   end
 
   @empty_param ~S/^\s*?[-\w]+?\s*?$/

--- a/test/calliope/integration_test.exs
+++ b/test/calliope/integration_test.exs
@@ -147,6 +147,6 @@ Outside the div
 
   @haml ".foo{a: 1, b: mystruct.key}"
   test :proper_attribute_fixing do
-    assert Calliope.Render.precompile(@haml) == "<div class=\"foo\" a='<%= 1 %>' b='<%= mystruct.key %>' ></div>\n"
+    assert Calliope.Render.precompile(@haml) == "<div class=\"foo\" a='<%= 1 %>' b='<%= mystruct.key %>'></div>\n"
   end
 end

--- a/test/calliope/integration_test.exs
+++ b/test/calliope/integration_test.exs
@@ -144,4 +144,9 @@ Outside the div
   test :preserves_newlines_with_comments do
     assert render(@haml) == @expected
   end
+
+  @haml ".foo{a: 1, b: mystruct.key}"
+  test :proper_attribute_fixing do
+    assert Calliope.Render.precompile(@haml) == "<div class=\"foo\" a='<%= 1 %>' b='<%= mystruct.key %>' ></div>\n"
+  end
 end


### PR DESCRIPTION
This ensures that the attribute parsing goes a little nicer, and at least does not break on the access operator `.` anymore.

Note that nested maps are not possible by this PR, because for this, an overhaul of the way Calliope parses attributes (`Calliope.Parser.build_attributes`) is necessary that uses LR or LL parsing instead of string replacements.